### PR TITLE
Implement getPlayerScore()

### DIFF
--- a/contracts/PrisonersDilemma.sol
+++ b/contracts/PrisonersDilemma.sol
@@ -80,36 +80,3 @@ contract PrisonersDilemma {
 
     //function to get winner
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/contracts/PrisonersDilemma.sol
+++ b/contracts/PrisonersDilemma.sol
@@ -71,7 +71,7 @@ contract PrisonersDilemma {
     }
 
     //function to get a player's scores
-    function getPlayerScore(address playerAddr) public returns (uint){
+    function getPlayerScore(address playerAddr) public view returns (uint){
 
         //require the player is in the map in order to look them up
         require(players[playerAddr].addr != address(0), "Player address is not in contract");

--- a/contracts/PrisonersDilemma.sol
+++ b/contracts/PrisonersDilemma.sol
@@ -71,6 +71,45 @@ contract PrisonersDilemma {
     }
 
     //function to get a player's scores
+    function getPlayerScore(address playerAddr) public returns (uint){
+
+        //require the player is in the map in order to look them up
+        require(players[playerAddr].addr != address(0), "Player address is not in contract");
+        return players[playerAddr].score;
+    }
+
     //function to get winner
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 

--- a/test/TestPrisonersDilemma.js
+++ b/test/TestPrisonersDilemma.js
@@ -60,5 +60,9 @@ contract('PrisonersDilemma', async (accounts) => {
     it("Test getPlayerScore()", async() => {
         //Test if address passed is not in the contract
         await expectThrow(instance.getPlayerScore(accounts[2], { from: accounts[0] })); 
+
+        //Test that a player's score can be retrieved        
+        var playerScore = await instance.getPlayerScore(accounts[0], { from: accounts[0] });
+        assert.equal(playerScore, 0, `player score ${ playerScore } does not match a score of 0`);
     });
 });

--- a/test/TestPrisonersDilemma.js
+++ b/test/TestPrisonersDilemma.js
@@ -56,4 +56,9 @@ contract('PrisonersDilemma', async (accounts) => {
         //Test player cannot pass an invalid choice
         await expectThrow(instance.playerChoose(9, { from: accounts[0] }));
     });
+
+    it("Test getPlayerScore()", async() => {
+        //Test if address passed is not in the contract
+        await expectThrow(instance.getPlayerScore(accounts[2], { from: accounts[0] })); 
+    });
 });


### PR DESCRIPTION
## Description
This will implement the getPlayerScore so that a player's score can be retrieved

## Changes
- Add method to get a player's score that is in the contract
- Addresses that are not in the contract will error
 
## Tests
- [x] Test that invalid user's score cannot be retrieved
- [x] Test that valid user's score can be retrieved
```
truffle test
Using network 'test'.

Compiling ./contracts/PrisonersDilemma.sol...

Compilation warnings encountered:

/Users/ejwessel/Dev/PrisonersDilemma/contracts/PrisonersDilemma.sol:44:9: Warning: Unused local variable.
        Player memory player1 = Player(_player1, ActionChoices.NoChoice, 0);
        ^-------------------^
,/Users/ejwessel/Dev/PrisonersDilemma/contracts/PrisonersDilemma.sol:45:9: Warning: Unused local variable.
        Player memory player2 = Player(_player2, ActionChoices.NoChoice, 0);
        ^-------------------^

Deploying contract with:
0x627306090abab3a6e1400e9345bc60c78a8bef57
0xf17f52151ebef6c7334fad080c5704d77216b732


  Contract: PrisonersDilemma
    ✓ Test Initial State of contract (52ms)
    ✓ Test invalid player not in contract (44ms)
    ✓ Test playerChoose() (184ms)
    ✓ Test getPlayerScore() (58ms)


  4 passing (414ms)
```