### PR TITLE
Pass in Player and Scoring Info

### DIFF
--- a/contracts/PrisonersDilemma.sol
+++ b/contracts/PrisonersDilemma.sol
@@ -25,6 +25,7 @@ contract PrisonersDilemma {
     event PlayersScoresTallied();
     event AlertWinner(address _player);
 
+    //TODO: read in player info, and scoring info
     constructor(address _player1, address _player2) public {
 
         players[_player1] = Player(_player1, ActionChoices.NoChoice, 0);

--- a/contracts/PrisonersDilemma.sol
+++ b/contracts/PrisonersDilemma.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.4.24;
 
 contract PrisonersDilemma {
 
-    //Constants
     enum ActionChoices { NoChoice, Share, Take }
 
     struct Player {
@@ -12,15 +11,15 @@ contract PrisonersDilemma {
     }
 
     //State Variables
+    uint private winning_score;
+    uint private greedy_points;
+    uint private mutual_points;
     address[] private playerList;
     mapping (address => Player) public players;
     address public winner = address(0); //empty address
-    uint private WINNING_SCORE;
-    uint private GREEDY_POINTS;
-    uint private MUTUAL_POINTS;
 
     //Events
-    event ContractInitialized(address _player1, address _player2);
+    event ContractInitialized(address player1Addr, address player2Addr, uint[] scoringData);
     event PlayerSelectedChoice(address _player);
     event PlayersScoresTallied();
     event AlertWinner(address _player);
@@ -42,11 +41,11 @@ contract PrisonersDilemma {
         players[player2Addr] = Player(player2Addr, player2Choice, player2Score);
         playerList.push(player2Addr);
 
-        WINNING_SCORE = _scoringData[0];
-        GREEDY_POINTS = _scoringData[1];
-        MUTUAL_POINTS = _scoringData[2];
+        winning_score = _scoringData[0];
+        greedy_points = _scoringData[1];
+        mutual_points = _scoringData[2];
 
-        emit ContractInitialized(player1Addr, player2Addr);
+        emit ContractInitialized(player1Addr, player2Addr, _scoringData);
     }
 
     //Functions:
@@ -88,12 +87,12 @@ contract PrisonersDilemma {
 
         //tally player scores
         if(player1.choice == ActionChoices.Share && player2.choice == ActionChoices.Share){
-            player2.score += MUTUAL_POINTS;
-            player1.score += MUTUAL_POINTS;
+            player2.score += mutual_points;
+            player1.score += mutual_points;
         } else if (player1.choice == ActionChoices.Share && player2.choice == ActionChoices.Take) {
-            player2.score += GREEDY_POINTS;
+            player2.score += greedy_points;
         } else if (player1.choice == ActionChoices.Take && player2.choice == ActionChoices.Share) {
-            player1.score += GREEDY_POINTS;
+            player1.score += greedy_points;
         }
         //Implicit else both players are awarded 0 points
 
@@ -109,13 +108,13 @@ contract PrisonersDilemma {
         Player storage player1 = players[playerList[0]];
         Player storage player2 = players[playerList[1]];
         
-        if (player1.score < WINNING_SCORE && player2.score < WINNING_SCORE) {
+        if (player1.score < winning_score && player2.score < winning_score) {
             //no winner keep playing
             return;
-        } else if(player1.score >= WINNING_SCORE && player2.score >= WINNING_SCORE) {
+        } else if(player1.score >= winning_score && player2.score >= winning_score) {
             //there is no winner, set the winner as the contract
             winner = this;
-        } else if (player1.score >= WINNING_SCORE) {
+        } else if (player1.score >= winning_score) {
             winner = player1.addr;
         } else {
             winner = player2.addr;

--- a/contracts/PrisonersDilemma.sol
+++ b/contracts/PrisonersDilemma.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.24;
 
+/** @title Prisoners Dilemma **/
 contract PrisonersDilemma {
 
     enum ActionChoices { NoChoice, Share, Take }
@@ -24,6 +25,12 @@ contract PrisonersDilemma {
     event PlayersScoresTallied();
     event AlertWinner(address _player);
 
+    /** @dev Instantiates the Prisoners Dilemma
+      * @param _player1 An array of Player 1 data [address, initialChoice, initialScore]
+      * @param _player2 An array of Player 2 data [address, initialChoice, initialScore]
+      * @param _scoringData An array of scoring data that the game is going to follow 
+      * [winning score, greedy score, mutual score]
+      */
     constructor(uint[] _player1, uint[] _player2, uint[] _scoringData) public {
 
         address player1Addr = address(_player1[0]);
@@ -53,9 +60,10 @@ contract PrisonersDilemma {
         checkForWinner();
     }
 
-    //Functions:
-    //function for a player to select a choice
-    function playerChoose(ActionChoices choice) public returns (ActionChoices){ 
+    /** @dev Function for a player to select a choice
+      * @param choice the players choice that needs to be saved
+      */
+    function playerChoose(ActionChoices choice) public { 
 
         //Require player is within the players mapping
         //0 is default value. We aren't going to allow default values
@@ -79,6 +87,7 @@ contract PrisonersDilemma {
         checkForWinner();
     }
 
+    /** @dev Tallies the player's scores given their choices */
     function tallyPlayerScores() private {
         //get players
         Player storage player1 = players[playerList[0]];
@@ -108,6 +117,7 @@ contract PrisonersDilemma {
         emit PlayersScoresTallied();
     }
 
+    /** @dev Method checks for a winner given the points of the users */
     function checkForWinner() private {
         //get players
         Player storage player1 = players[playerList[0]];
@@ -127,7 +137,10 @@ contract PrisonersDilemma {
         emit AlertWinner(winner);
     }
 
-    //function to get a player's scores
+    /** @dev Function to get a player's scores
+      * @param playerAddr the players address we want to get a score for
+      * @return the player's score
+      */
     function getPlayerScore(address playerAddr) public view returns (uint){
 
         //require the player is in the map in order to look them up

--- a/contracts/PrisonersDilemma.sol
+++ b/contracts/PrisonersDilemma.sol
@@ -3,9 +3,6 @@ pragma solidity ^0.4.24;
 contract PrisonersDilemma {
 
     //Constants
-    uint constant private WINNING_SCORE = 20;
-    uint constant private GREEDY_POINTS = 5;
-    uint constant private MUTUAL_POINTS = 1;
     enum ActionChoices { NoChoice, Share, Take }
 
     struct Player {
@@ -18,6 +15,9 @@ contract PrisonersDilemma {
     address[] private playerList;
     mapping (address => Player) public players;
     address public winner = address(0); //empty address
+    uint private WINNING_SCORE;
+    uint private GREEDY_POINTS;
+    uint private MUTUAL_POINTS;
 
     //Events
     event ContractInitialized(address _player1, address _player2);
@@ -25,16 +25,28 @@ contract PrisonersDilemma {
     event PlayersScoresTallied();
     event AlertWinner(address _player);
 
-    //TODO: read in player info, and scoring info
-    constructor(address _player1, address _player2) public {
+    constructor(uint[] _player1, uint[] _player2, uint[] _scoringData) public {
 
-        players[_player1] = Player(_player1, ActionChoices.NoChoice, 0);
-        playerList.push(_player1);
+        address player1Addr = address(_player1[0]);
+        address player2Addr = address(_player2[0]);
+
+        ActionChoices player1Choice = ActionChoices(_player1[1]);
+        ActionChoices player2Choice = ActionChoices(_player2[1]);
+
+        uint player1Score = _player1[2];
+        uint player2Score = _player2[2];
+
+        players[player1Addr] = Player(player1Addr, player1Choice, player1Score);
+        playerList.push(player1Addr);
         
-        players[_player2] = Player(_player2, ActionChoices.NoChoice, 0);
-        playerList.push(_player2);
+        players[player2Addr] = Player(player2Addr, player2Choice, player2Score);
+        playerList.push(player2Addr);
 
-        emit ContractInitialized(_player1, _player2);
+        WINNING_SCORE = _scoringData[0];
+        GREEDY_POINTS = _scoringData[1];
+        MUTUAL_POINTS = _scoringData[2];
+
+        emit ContractInitialized(player1Addr, player2Addr);
     }
 
     //Functions:

--- a/contracts/PrisonersDilemma.sol
+++ b/contracts/PrisonersDilemma.sol
@@ -46,6 +46,11 @@ contract PrisonersDilemma {
         mutual_points = _scoringData[2];
 
         emit ContractInitialized(player1Addr, player2Addr, _scoringData);
+
+        //provided if we pass in player state we should tally and check for winner
+        //this will add gas cost
+        tallyPlayerScores();
+        checkForWinner();
     }
 
     //Functions:

--- a/test/TestPrisonersDilemma.js
+++ b/test/TestPrisonersDilemma.js
@@ -7,7 +7,10 @@ var EMPTY_ADDRESS = "0x0000000000000000000000000000000000000000";
 contract('PrisonersDilemma', async (accounts) => {
 
     beforeEach(async() => {
-        instance = await PrisonersDilemma.new(accounts[0], accounts[1]);
+        instance = await PrisonersDilemma.new(
+            [accounts[0], CHOICES[0], 0], 
+            [accounts[1], CHOICES[0], 0],
+            [20, 5, 1]);
     });
 
     it("Test Initial State of contract", async() => {

--- a/test/TestPrisonersDilemma.js
+++ b/test/TestPrisonersDilemma.js
@@ -8,8 +8,8 @@ contract('PrisonersDilemma', async (accounts) => {
 
     beforeEach(async() => {
         instance = await PrisonersDilemma.new(
-            [accounts[0], CHOICES[0], 0], 
-            [accounts[1], CHOICES[0], 0],
+            [accounts[0], CHOICES["No_Choice"], 0], 
+            [accounts[1], CHOICES["No_Choice"], 0],
             [20, 5, 1]);
     });
 
@@ -69,8 +69,81 @@ contract('PrisonersDilemma', async (accounts) => {
         assert.equal(playerScore, 0, `player score ${ playerScore } does not match a score of 0`);
     });
     
+    it("Test player choices reset", async() => {
+        instance = await PrisonersDilemma.new(
+            [accounts[0], CHOICES["Take"], 0], 
+            [accounts[1], CHOICES["Take"], 0],
+            [1, 1, 1]);
+
+        var player1 = await instance.players.call(accounts[0]);
+        var player2 = await instance.players.call(accounts[1]);
+
+        //both player choices should be reset
+        assert.equal(player1[1].toNumber(), 0, "Player 1 choice was not reset");
+        assert.equal(player2[1].toNumber(), 0, "Player 2 choice was not reset");
+    });
+
     it("Test scoring with 1 winner", async() => {
-        //Round 1
+        instance = await PrisonersDilemma.new(
+            [accounts[0], CHOICES["Share"], 0], 
+            [accounts[1], CHOICES["Take"], 0],
+            [1, 1, 1]);
+
+        var player1 = await instance.players.call(accounts[0]);
+        var player2 = await instance.players.call(accounts[1]);
+    
+        //there should have been a winner
+        var player1Score = await instance.getPlayerScore(accounts[0]);
+        var player2Score = await instance.getPlayerScore(accounts[1]);
+        assert.equal(player1Score, 0, `Player 1 points should be 0, not ${ player1Score }`);
+        assert.equal(player2Score, 1, `Player 2 points should be 1, not ${ player2Score }`);
+
+        var contractWinner = await instance.winner();
+        assert.equal(contractWinner, accounts[1], `contract winner ${ contractWinner }, does not match expected ${ accounts[1] }`);
+
+        //Test if a player can continue to play after there is a winner
+        await expectThrow(instance.playerChoose(CHOICES["Take"], { from: accounts[0] }))
+    });
+    
+    it("Test scoring with no winner", async() => {
+        instance = await PrisonersDilemma.new(
+            [accounts[0], CHOICES["Share"], 0], 
+            [accounts[1], CHOICES["Share"], 0],
+            [1, 1, 1]);
+
+        var player1 = await instance.players.call(accounts[0]);
+        var player2 = await instance.players.call(accounts[1]);
+    
+        //there should be no winner
+        var player1Score = await instance.getPlayerScore(accounts[0]);
+        var player2Score = await instance.getPlayerScore(accounts[1]);
+        assert.equal(player1Score, 1, `Player 1 points should be 1, not ${ player1Score }`);
+        assert.equal(player2Score, 1, `Player 2 points should be 1, not ${ player2Score }`);
+
+        var contractWinner = await instance.winner();
+        assert.equal(contractWinner, instance.address, `contract winner ${ contractWinner }, does not match expected ${ instance.address }`);
+
+        //Test if a player can continue to play after the game is over with no winner
+        await expectThrow(instance.playerChoose(CHOICES["Take"], { from: accounts[0] }))
+    });
+
+    it("Test scoring with no progression", async() => {
+        instance = await PrisonersDilemma.new(
+            [accounts[0], CHOICES["Take"], 0], 
+            [accounts[1], CHOICES["Take"], 0],
+            [1, 1, 1]);
+
+        var player1 = await instance.players.call(accounts[0]);
+        var player2 = await instance.players.call(accounts[1]);
+    
+        //there should be no winner
+        var player1Score = await instance.getPlayerScore(accounts[0]);
+        var player2Score = await instance.getPlayerScore(accounts[1]);
+        assert.equal(player1Score, 0, `Player 1 points should be 0, not ${ player1Score }`);
+        assert.equal(player2Score, 0, `Player 2 points should be 0, not ${ player2Score }`);
+    });
+
+    it("Test an actual game", async() => {
         await instance.playerChoose(CHOICES["Share"], { from: accounts[0] });
         await instance.playerChoose(CHOICES["Share"], { from: accounts[1] });
 
@@ -97,52 +170,5 @@ contract('PrisonersDilemma', async (accounts) => {
 
         //Test if a player can continue to play after there is a winner
         await expectThrow(instance.playerChoose(CHOICES["Take"], { from: accounts[0] }))
-    });
-    
-    it("Test scoring with no winner", async() => {
-
-        //create 20 rounds
-        for(i = 0; i < 20; i++) {
-            await instance.playerChoose(CHOICES["Share"], { from: accounts[0] });
-            await instance.playerChoose(CHOICES["Share"], { from: accounts[1] });
-        }
-
-        var player1 = await instance.players.call(accounts[0]);
-        var player2 = await instance.players.call(accounts[1]);
-    
-        //both player choices should be reset
-        assert.equal(player1[1].toNumber(), 0, "Player 1 choice was not reset");
-        assert.equal(player2[1].toNumber(), 0, "Player 2 choice was not reset");
-
-        //there should be no winner
-        var player1Score = await instance.getPlayerScore(accounts[0]);
-        var player2Score = await instance.getPlayerScore(accounts[1]);
-        assert.equal(player1Score, 20, `Player 1 points should be 20, not ${ player1Score }`);
-        assert.equal(player2Score, 20, `Player 2 points should be 20, not ${ player2Score }`);
-
-        var contractWinner = await instance.winner();
-        assert.equal(contractWinner, instance.address, `contract winner ${ contractWinner }, does not match expected ${ instance.address }`);
-    });
-
-    it("Test scoring with no progression", async() => {
-
-        //create 2 rounds
-        for(i = 0; i < 2; i++) {
-            await instance.playerChoose(CHOICES["Take"], { from: accounts[0] });
-            await instance.playerChoose(CHOICES["Take"], { from: accounts[1] });
-        }
-
-        var player1 = await instance.players.call(accounts[0]);
-        var player2 = await instance.players.call(accounts[1]);
-    
-        //both player choices should be reset
-        assert.equal(player1[1].toNumber(), 0, "Player 1 choice was not reset");
-        assert.equal(player2[1].toNumber(), 0, "Player 2 choice was not reset");
-
-        //there should be no winner
-        var player1Score = await instance.getPlayerScore(accounts[0]);
-        var player2Score = await instance.getPlayerScore(accounts[1]);
-        assert.equal(player1Score, 0, `Player 1 points should be 0, not ${ player1Score }`);
-        assert.equal(player2Score, 0, `Player 2 points should be 0, not ${ player2Score }`);
     });
 });


### PR DESCRIPTION
## Description
To facilitate easier testing. I want to be able to dynamically set the scoring and player states. This is not something I want done on usage of the contract by individuals, but will help prevent test bloat. It subsequently allows dynamic scoring and player state.
 
## Changes
```
constructor(player_1_info, player_2_info, scoring_array)
constructor([address, choice, score], [address, choice, score], [winning, greed, share])
```
- shortened tests by mocking states


## Tests
```
Using network 'test'.

Compiling ./contracts/PrisonersDilemma.sol...


  Contract: PrisonersDilemma
    ✓ Test Initial State of contract (52ms)
    ✓ Test invalid player not in contract
    ✓ Test playerChoose() (173ms)
    ✓ Test getPlayerScore() (39ms)
    ✓ Test player choices reset (149ms)
    ✓ Test scoring with 1 winner (221ms)
    ✓ Test scoring with no winner (230ms)
    ✓ Test scoring with no progression (163ms)
    ✓ Test an actual game (598ms)


  9 passing (3s)
```