### PR TITLE
Inject Greedy Score

### DIFF
--- a/contracts/PrisonersDilemma.sol
+++ b/contracts/PrisonersDilemma.sol
@@ -15,6 +15,7 @@ contract PrisonersDilemma {
     uint private winning_score;
     uint private greedy_points;
     uint private mutual_points;
+    uint private mutual_greedy_points;
     address[] private playerList;
     mapping (address => Player) public players;
     address public winner = address(0); //empty address
@@ -30,7 +31,7 @@ contract PrisonersDilemma {
       * @param _player1 An array of Player 1 data [address, initialChoice, initialScore]
       * @param _player2 An array of Player 2 data [address, initialChoice, initialScore]
       * @param _scoringData An array of scoring data that the game is going to follow 
-      * [winning score, greedy score, mutual score]
+      * [winning score, greedy score, mutual score, mutual greedy score]
       */
     constructor(uint[] _player1, uint[] _player2, uint[] _scoringData) public {
 
@@ -52,6 +53,7 @@ contract PrisonersDilemma {
         winning_score = _scoringData[0];
         greedy_points = _scoringData[1];
         mutual_points = _scoringData[2];
+        mutual_greedy_points = _scoringData[3];
 
         emit ContractInitialized(player1Addr, player2Addr, _scoringData);
 
@@ -108,8 +110,11 @@ contract PrisonersDilemma {
             player2.score += greedy_points;
         } else if (player1.choice == ActionChoices.Take && player2.choice == ActionChoices.Share) {
             player1.score += greedy_points;
+        } else {
+            //last choice is take/take
+            player1.score += mutual_greedy_points;
+            player2.score += mutual_greedy_points;
         }
-        //Implicit else both players are awarded 0 points
 
         //reset player choices for next round
         player1.choice = ActionChoices.NoChoice;

--- a/test/TestPrisonersDilemma.js
+++ b/test/TestPrisonersDilemma.js
@@ -15,7 +15,7 @@ contract('PrisonersDilemma', async (accounts) => {
         instance = await PrisonersDilemma.new(
             [accounts[0], CHOICES["No_Choice"], 0], 
             [accounts[1], CHOICES["No_Choice"], 0],
-            [20, 5, 1]);
+            [20, 5, 1, 0]);
     });
 
     afterEach(async() => {
@@ -82,7 +82,7 @@ contract('PrisonersDilemma', async (accounts) => {
         instance = await PrisonersDilemma.new(
             [accounts[0], CHOICES["Take"], 0], 
             [accounts[1], CHOICES["Take"], 0],
-            [1, 1, 1]);
+            [1, 1, 1, 0]);
 
         var player1 = await instance.players(accounts[0]);
         var player2 = await instance.players(accounts[1]);
@@ -96,7 +96,7 @@ contract('PrisonersDilemma', async (accounts) => {
         instance = await PrisonersDilemma.new(
             [accounts[0], CHOICES["Share"], 0], 
             [accounts[1], CHOICES["Take"], 0],
-            [1, 1, 1]);
+            [1, 1, 1, 0]);
 
         var player1 = await instance.players(accounts[0]);
         var player2 = await instance.players(accounts[1]);
@@ -118,7 +118,7 @@ contract('PrisonersDilemma', async (accounts) => {
         instance = await PrisonersDilemma.new(
             [accounts[0], CHOICES["Share"], 0], 
             [accounts[1], CHOICES["Share"], 0],
-            [1, 1, 1]);
+            [1, 1, 1, 0]);
 
         var player1 = await instance.players(accounts[0]);
         var player2 = await instance.players(accounts[1]);
@@ -140,7 +140,7 @@ contract('PrisonersDilemma', async (accounts) => {
         instance = await PrisonersDilemma.new(
             [accounts[0], CHOICES["Take"], 0], 
             [accounts[1], CHOICES["Take"], 0],
-            [1, 1, 1]);
+            [1, 1, 1, 0]);
 
         var player1 = await instance.players(accounts[0]);
         var player2 = await instance.players(accounts[1]);


### PR DESCRIPTION
## Description
I wanted the ability to set all the rules of game with regard to scoring.
## Changes
Added the ability to define the greedy score when two players take/take

## Test
```
Using network 'test'.

Compiling ./contracts/PrisonersDilemma.sol...


  Contract: PrisonersDilemma
	Web 3 Api Version: 0.20.6
	Web 3 Ethreum Version: 63
    ✓ Test Initial State of contract (48ms)
    ✓ Test invalid player not in contract
    ✓ Test playerChoose() (168ms)
    ✓ Test getPlayerScore()
    ✓ Test player choices reset (148ms)
    ✓ Test scoring with 1 winner (251ms)
    ✓ Test scoring with no winner (211ms)
    ✓ Test scoring with no progression (156ms)
    ✓ Test an actual game (565ms)
	contract creation gas estimate: 1494043
	playerChoose() gas estimate: 33638
	endGame() gas estimate: 13588
    ✓ Gas Analysis (202ms)


  10 passing (4s)
```